### PR TITLE
[fix/orientation-android-8-sdk-26] Only fullscreen opaque activities can request orientation on Android 8 (SDK 26)

### DIFF
--- a/android/app/src/main/res/values-v26/styles.xml
+++ b/android/app/src/main/res/values-v26/styles.xml
@@ -1,0 +1,6 @@
+<resources>
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowIsTranslucent">false</item>
+        <item name="android:windowIsFloating">false</item>
+    </style>
+</resources>


### PR DESCRIPTION
### Summary 
Fix issue:  `java.lang.IllegalStateException: Only fullscreen opaque activities can request orientation`
This issue only occurs on android 8 (SDK 26)
### Checklist 

-   [ ] I removed all commented or unnecessary code.
-   [x] Provide the screenshots due to UI changed or bug fixed
-   [ ] My code has covered these test cases (please list down your tested cases):

Bug: (run on android emulator  android 8 (SDK 26))  

https://user-images.githubusercontent.com/34257375/164910439-9134dfd6-4009-4f4f-9a6f-4a6b1347b55a.mov

Fixed: (run on android emulator  android 8 (SDK 26))  

https://user-images.githubusercontent.com/34257375/164910444-20566f2a-4398-4820-a848-42b063b8814e.mov


