### PR TITLE
[fix/camera-usage-info-plist] fix key NSCameraUsageDescription string

### DIFF
--- a/ios/CasperDash/Info.plist
+++ b/ios/CasperDash/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CodePushDeploymentKey</key>
 	<string>PEuhtbin9q4psJtEqhufLI5PozrJuSlMrrVUY</string>
 	<key>LSApplicationQueriesSchemes</key>
@@ -65,14 +65,12 @@
 	<string>$(PRODUCT_NAME) will able to discover and connect to devices on the networks you use</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>$(PRODUCT_NAME) will able to discover and connect to devices on the networks you use</string>
-	<key>NSCameraUsageDescription</key>
-	<string>$(PRODUCT_NAME} use to scan QR Code</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>$(PRODUCT_NAME) use to save image to your library</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>$(PRODUCT_NAME) use to upload your avatar</string>
+	<key>NSCameraUsageDescription</key>
+	<string>$(PRODUCT_NAME) need to access your camera for scanning QR Code to get receiver’s public key</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>AntDesign.ttf</string>


### PR DESCRIPTION
### Summary 
Fix key NSCameraUsageDescription string

> We identified one or more issues with a recent delivery for your app, "CasperDash" 1.0.2 (3). Please correct the following issues, then upload again.
> 
> ITMS-90683: Missing Purpose String in Info.plist - Your app's code references one or more APIs that access sensitive user data. The app's Info.plist file should contain a NSCameraUsageDescription key with a user-facing purpose string explaining clearly and completely why your app needs the data. Starting Spring 2019, all apps submitted to the App Store that access user data are required to include a purpose string. If you're using external libraries or SDKs, they may reference APIs that require a purpose string. While your app might not use these APIs, a purpose string is still required. You can contact the developer of the library or SDK and request they release a version of their code that doesn't contain the APIs. Learn more (https://developer.apple.com/documentation/uikit/core_app/protecting_the_user_s_privacy).

### Checklist (If you won't pass this checklist please comment why)

-   [ ] I removed all commented or unnecessary code.
-   [ ] Provide the screenshots due to UI changed or bug fixed
-   [ ] My code has covered these test cases (please list down your tested cases):
