### PR TITLE
Fix: Remove 1 byte (v) on signature when signing message with ledger 

### DIFF
--- a/src/screens/browser/components/ModalRequestAction/SignMessageContent/index.tsx
+++ b/src/screens/browser/components/ModalRequestAction/SignMessageContent/index.tsx
@@ -27,6 +27,7 @@ const SignMessageContent = ({ onClose, params }: Props) => {
     const signedMessage = await signMessageAsync({
       message: params.message,
     });
+
     const jsScript = buildRawSender(RequestTypes.SIGN_MESSAGE, `'${signedMessage}'`);
 
     browserRef.current.injectJavaScript(jsScript);

--- a/src/utils/hooks/useSignDeploy.ts
+++ b/src/utils/hooks/useSignDeploy.ts
@@ -25,7 +25,7 @@ export const useSignDeploy = (wallet?: WalletInfo, options?: UseMutationOptions<
         if (loginOptions.connectionType === CONNECTION_TYPES.ledger) {
           return await signDeployByLedger(deploy, {
             publicKey: mainAccountHex,
-            keyIndex: loginOptions.keyIndex,
+            keyIndex: wallet?.uid,
           });
         } else {
           if (!wallet) {

--- a/src/utils/hooks/useSignMessage.ts
+++ b/src/utils/hooks/useSignMessage.ts
@@ -21,7 +21,7 @@ export const useSignMessage = (wallet?: WalletInfo, options?: UseMutationOptions
       try {
         if (loginOptions.connectionType === CONNECTION_TYPES.ledger) {
           return signMessage(message, {
-            keyIndex: loginOptions.keyIndex,
+            keyIndex: wallet?.uid,
           });
         } else {
           if (!wallet) {

--- a/src/utils/services/ledgerServices.ts
+++ b/src/utils/services/ledgerServices.ts
@@ -1,4 +1,4 @@
-import { DeployUtil, CLPublicKey } from 'casperdash-js-sdk';
+import { DeployUtil, CLPublicKey, formatMessageWithHeaders, encodeBase16 } from 'casperdash-js-sdk';
 import CasperApp from '@zondax/ledger-casper';
 import { SECP256k1, CONNECT_ERROR_MESSAGE } from '../constants/ledger';
 import { CASPER_KEY_PATH } from '../constants/key';
@@ -71,11 +71,9 @@ export const signMessage = async (
 ): Promise<string> => {
   const { casperApp, transport } = await initLedgerApp();
 
-  const ledgerPrefix = 'Casper Message:\n';
-
   const signatureResponse = await casperApp.signMessage(
     `${CASPER_KEY_PATH}${keyIndex}`,
-    Buffer.from(`${ledgerPrefix}${message}`, 'utf8'),
+    formatMessageWithHeaders(message) as Buffer,
   );
 
   if (!signatureResponse) {
@@ -86,7 +84,9 @@ export const signMessage = async (
 
   await transport.close();
 
-  return Buffer.from(signatureResponse.signatureRSV).toString('hex');
+  const signature = Uint8Array.from(signatureResponse.signatureRSV);
+
+  return encodeBase16(signature.slice(0, 64));
 };
 
 /**


### PR DESCRIPTION
### Summary (Please recap what you changed or fixed)
With signatureRSV we have:

```
signature:   32 bytes (r component) + 32 bytes (s component) + 1 byte (v component)
```

Signature message only need: r + s = 64 bytes

### Checklist (If you won't pass this checklist please comment why)

-   [x] I removed all commented or unnecessary code.
-   [ ] Provide the screenshots due to UI changed or bug fixed
-   [ ] My code has covered these test cases (please list down your tested cases):
