### PR TITLE
Fix: Parse error decimals from hex token

### DIFF
--- a/src/utils/helpers/currency.ts
+++ b/src/utils/helpers/currency.ts
@@ -43,7 +43,19 @@ export const toCSPRFromHex = (amountHex: string | number): Big => {
   try {
     const bigAmount = BigNumber.from(amountHex);
 
-    return toCSPR(bigAmount.toNumber());
+    return toCSPR(bigAmount.toString());
+  } catch (error) {
+    return new Big(0);
+  }
+};
+
+export const toBigFromDecimalHex = (amount: string | number, decimalHex: number | string): Big => {
+  try {
+    return new Big(
+      BigNumber.from(amount)
+        .pow(decimalHex ?? 0)
+        .toString(),
+    );
   } catch (error) {
     return new Big(0);
   }

--- a/src/utils/selectors/tokens.ts
+++ b/src/utils/selectors/tokens.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { ITokenInfoResponse } from 'services/User/userTypes';
 import Big from 'big.js';
+import { toBigFromDecimalHex } from "utils/helpers/currency";
 
 export const tokensSelector = (state: any) => state.home;
 
@@ -11,27 +12,27 @@ export const getMassagedTokenData = (data: ITokenInfoResponse[]): ITokenInfoResp
   }
 
   return data.map<ITokenInfoResponse>((datum) => {
-    const decimals = new Big(
-      BigNumber.from(10)
-        .pow(datum?.decimals?.hex ?? 0)
-        .toNumber(),
-    );
+    const decimals = toBigFromDecimalHex(10, datum?.decimals?.hex ?? 0);
+    const isNotZero = !decimals.eq(0);
 
     return {
       ...datum,
       balance: {
         ...datum.balance,
-        displayValue: new Big(BigNumber.from(datum?.balance?.hex ?? 0).toNumber()).div(decimals).toNumber(),
+        displayValue: isNotZero
+          ? new Big(BigNumber.from(datum?.balance?.hex ?? 0).toString()).div(decimals).toNumber()
+          : 0,
       },
       total_supply: {
         ...datum.total_supply,
-        displayValue: datum.total_supply?.hex
-          ? new Big(BigNumber.from(datum.total_supply.hex).toNumber()).div(decimals).toNumber()
-          : 0,
+        displayValue:
+          datum.total_supply?.hex && isNotZero
+            ? new Big(BigNumber.from(datum.total_supply.hex).toString()).div(decimals).toNumber()
+            : 0,
       },
       decimals: {
         ...datum.decimals,
-        displayValue: datum.decimals?.hex ? BigNumber.from(datum.decimals.hex).toNumber() : 0,
+        displayValue: isNotZero && datum.decimals?.hex ? BigNumber.from(datum.decimals.hex).toNumber() : 0,
       },
     };
   });


### PR DESCRIPTION
### Summary (Please recap what you changed or fixed)
- With hex from `datum?.decimals?.hex = 0x12 = 18 ` so `1e18 > Number.MAX_SAFE_INTEGER`, BigNumber will return error
### Checklist (If you won't pass this checklist please comment why)

-   [x] I removed all commented or unnecessary code.
-   [x] Provide the screenshots due to UI changed or bug fixed
-   [ ] My code has covered these test cases (please list down your tested cases):
